### PR TITLE
Accept mode param in image size definition

### DIFF
--- a/lib/image/imagemagick.js
+++ b/lib/image/imagemagick.js
@@ -238,9 +238,9 @@ module.exports = {
       }
 
       _.each(imageSizes, function(size) {
-		    args.push('(');
+        args.push('(');
         args.push('-clone');
-        rgs.push('0--1');
+        args.push('0--1');
         args.push('-resize');
         if (size.mode && size.mode == 'cropCenter') {
           args.push(size.width + 'x' + size.height + '^');


### PR DESCRIPTION
This modification adds the possibility to add a new parameter in the images size definition: mode.

If mode = 'cropCenter', the image will be cropped to match the specified dimensions, no matter the original aspect ratio.
If not specified the default behavior will be applied.

This is handy if you need to have different aspect ratios in the same image, by cropping them centered. If the image is smaller than the required dimensions, it will be amplified.

For instance:

  addImageSizes:
  [
        {
            name: 'listado-1',
            mode: 'cropCenter',
            width: 440,
            height: 250
        }
  ]
