### PR TITLE
Added bucketObjectsACL options to s3.js

### DIFF
--- a/lib/storage/s3.js
+++ b/lib/storage/s3.js
@@ -14,6 +14,7 @@ module.exports = function() {
   var cachingTime;
   var https;
   var bucket;
+  var bucketObjectsACL;
   var endpoint;
   var defaultTypes;
   var noProtoEndpoint;
@@ -26,6 +27,7 @@ module.exports = function() {
         options.credentials = new AWS.Credentials(options.key, options.secret, options.token || null);
       }
       bucket = options.bucket;
+      bucketObjectsACL = options.bucketObjectsACL || "public-read";
       options.params = options.params || {};
       options.params.Bucket = options.params.Bucket || options.bucket;
       // bc for the `endpoint`, `secure` and `port` options
@@ -86,7 +88,7 @@ module.exports = function() {
       var inputStream = fs.createReadStream(localPath);
 
       var params = {
-        ACL: 'public-read',
+        ACL: bucketObjectsACL,
         Key: cleanKey(path),
         Body: inputStream,
         ContentType: contentType


### PR DESCRIPTION
Added bucketObjectsACL option to s3.js to allow override of default 'public-read' permission when using a restricted S3 bucket to store assets per discussion in issue #55

