### PR TITLE
allow custom image sizes on an individual call to copyImageIn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## CHANGES IN 1.18.0
+* Support for a `sizes` option when calling `copyImageIn`, removing the requirement that all uploads are scaled to the same set of sizes. If the option is not provided the globally configured sizes are used.
+
 ## CHANGES IN 1.17.2
 * Documented the `endpoint` option. Thanks to Joe Innes for this contribution.
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ You need:
 
 * The default JPEG quality setting for scaled-down versions of your image is `80`. This avoids unacceptably large file sizes for web deployment. You can adjust this via the `scaledJpegQuality` option, either when initializing uploadfs or when calling `copyImageIn`.
 
+* If you do not wish to always use the same set of image sizes, you may pass a `sizes` property as part of the options object when calling `copyImageIn`.
+
 * The `copyOut` method takes a path in uploadfs and a local filename and copies the file back from uploadfs to the local filesystem. This should be used only rarely. Heavy reliance on this method sets you up for poor performance in S3 and Azure. However it may be necessary at times, for instance when you want to crop an image differently later. *Heavy reliance on copyOut is a recipe for bad S3 and/or Azure performance. Use it only for occasional operations like cropping.*
 
 * The `remove` method removes a file from uploadfs.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uploadfs",
-  "version": "1.17.2",
+  "version": "1.18.0",
   "description": "Store files in a web-accessible location via a simplified API. Can automatically scale and rotate images. Includes S3, Azure and local filesystem-based backends with the most convenient features of each.",
   "main": "uploadfs.js",
   "scripts": {

--- a/uploadfs.js
+++ b/uploadfs.js
@@ -172,7 +172,8 @@ function Uploadfs() {
 
   /**
    * Copy an image into uploadfs. Scaled versions as defined by the imageSizes option
-   * at init() time are copied into uploadfs as follows:
+   * passed at init() time, or as overridden by `options.sizes` on this call,
+   * are copied into uploadfs as follows:
    *
    * If 'path' is '/me' and sizes with names 'small', 'medium' and 'large'
    * were defined at init() time, the scaled versions will be:
@@ -233,11 +234,13 @@ function Uploadfs() {
       options = {};
     }
 
+    var sizes = options.sizes || imageSizes;
+
     // We'll pass this context to the image processing backend with
     // additional properties
     var context = {
       crop: options.crop,
-      sizes: imageSizes
+      sizes: sizes
     };
 
     context.scaledJpegQuality = options.scaledJpegQuality || scaledJpegQuality;
@@ -275,7 +278,7 @@ function Uploadfs() {
         // Name the destination folder
         context.tempName = generateId();
         // Create destination folder
-        if (imageSizes.length) {
+        if (sizes.length) {
           context.tempFolder = tempPath + '/' + context.tempName;
           return fs.mkdir(context.tempFolder, callback);
         } else {
@@ -321,7 +324,7 @@ function Uploadfs() {
             // Nowhere to do the work
             return callback(null);
           }
-          var filenames = _.map(imageSizes, function(size) {
+          var filenames = _.map(sizes, function(size) {
             return context.tempFolder + '/' + size.name + '.' + context.extension;
           });
           return self.postprocess(filenames, callback);
@@ -348,7 +351,7 @@ function Uploadfs() {
       },
 
       copySizes: function(callback) {
-        return async.each(imageSizes, function(size, callback) {
+        return async.each(sizes, function(size, callback) {
           var suffix = size.name + '.' + context.extension;
           var tempFile = context.tempFolder + '/' + suffix;
           var permFile = context.basePath + '.' + suffix;


### PR DESCRIPTION
I have tested this with `npx mocha test/s3.js`, where I added an additional test. Due to the lack of any impact on the storage backend code it is not necessary to retest all backends, which requires quite a lot of setup.