### PR TITLE
Bug fix: the `sizes` option to `copyImageIn` now works even if `image…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## CHANGES IN 1.18.1
+* Bug fix: the `sizes` option to `copyImageIn` now works even if `imageSizes` was not passed at all when calling `init`.
+
 ## CHANGES IN 1.18.0
 * Support for a `sizes` option when calling `copyImageIn`, removing the requirement that all uploads are scaled to the same set of sizes. If the option is not provided the globally configured sizes are used.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uploadfs",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "description": "Store files in a web-accessible location via a simplified API. Can automatically scale and rotate images. Includes S3, Azure and local filesystem-based backends with the most convenient features of each.",
   "main": "uploadfs.js",
   "scripts": {

--- a/uploadfs.js
+++ b/uploadfs.js
@@ -19,6 +19,7 @@ function generateId() {
 function Uploadfs() {
   var tempPath, imageSizes;
   var scaledJpegQuality;
+  var ensuredTempDir = false;
   var self = this;
   /**
    * Initialize uploadfs. The init method passes options to the backend and invokes a callback when the backend is ready.
@@ -79,6 +80,8 @@ function Uploadfs() {
 
     imageSizes = options.imageSizes || [];
 
+    tempPath = options.tempPath;
+
     async.series([
       // create temp folder if needed
       function (callback) {
@@ -86,11 +89,7 @@ function Uploadfs() {
           return callback();
         }
 
-        tempPath = options.tempPath;
-
-        if (!fs.existsSync(options.tempPath)) {
-          fs.mkdirSync(options.tempPath);
-        }
+        ensureTempDir();
         return callback(null);
       },
 
@@ -235,6 +234,8 @@ function Uploadfs() {
     }
 
     var sizes = options.sizes || imageSizes;
+
+    ensureTempDir();
 
     // We'll pass this context to the image processing backend with
     // additional properties
@@ -553,6 +554,15 @@ function Uploadfs() {
   function prefixPath(path) {
     // Resolve any double // that results from the prefix
     return (self.prefix + path).replace(/\/\//g, '/');
+  }
+
+  function ensureTempDir() {
+    if (!ensuredTempDir) {
+      if (!fs.existsSync(tempPath)) {
+        fs.mkdirSync(tempPath);
+      }
+      ensuredTempDir = true;
+    }
   }
 
 }


### PR DESCRIPTION
…Sizes` was not passed at all when calling `init`.