### PR TITLE
Resolve npm audit concerns except for those caused by azure-storage

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,10 @@
 {
   "extends": "apostrophe",
   "rules": {
-    "no-console": 0
+    "no-console": 0,
+    "multiline-ternary": 0,
+    "node/no-path-concat": 0,
+    "node/no-callback-literal": 0
   },
   "overrides": [
     {

--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,6 @@
   "extends": "apostrophe",
   "rules": {
     "no-console": 0,
-    "multiline-ternary": 0,
     "node/no-path-concat": 0,
     "node/no-callback-literal": 0
   },

--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,6 @@
   "extends": "apostrophe",
   "rules": {
     "no-console": 0,
-    "node/no-path-concat": 0,
     "node/no-callback-literal": 0
   },
   "overrides": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## CHANGES IN 1.18.2
+* Addressed `npm audit` complaints about `mkdirp` by using a simple `mkdirp` implementation that has no legacy compatibility issues.
+* Addressed `npm audit` complaints about `mocha` and friends by upgrading `mocha`.
+* There are currently `npm audit` warnings about `azure-storage`, however a fix for this is forthcoming according to the upstream maintainers, and the existing semver ranges in this package will pick it up on `npm audit` when released.
+
 ## CHANGES IN 1.18.1
 * Bug fix: the `sizes` option to `copyImageIn` now works even if `imageSizes` was not passed at all when calling `init`.
 

--- a/lib/copyFile.js
+++ b/lib/copyFile.js
@@ -5,12 +5,11 @@
 //
 // Creates any necessary parent folders of path2 automatically.
 
-var fs = require('fs');
-var dirname = require('path').dirname;
-var mkdirp = require('mkdirp');
+const fs = require('fs');
+const path = require('path');
 
-var copy = module.exports = function(path1, path2, options, callback) {
-  var failed = false;
+const copy = module.exports = function(path1, path2, options, callback) {
+  let failed = false;
   if (!callback) {
     callback = options;
     options = {};
@@ -18,8 +17,8 @@ var copy = module.exports = function(path1, path2, options, callback) {
   // Other people's implementations of fs.copy() lack
   // error handling, let's be thorough and also implement
   // a retry that does mkdirp() for consistency with S3
-  var sin = fs.createReadStream(path1);
-  var sout = fs.createWriteStream(path2);
+  const sin = fs.createReadStream(path1);
+  const sout = fs.createWriteStream(path2);
 
   sin.on('error', function(e) {
     if (failed) {
@@ -54,14 +53,13 @@ var copy = module.exports = function(path1, path2, options, callback) {
     // S3 backend anyway.
 
     if ((e.code === 'ENOENT') && ((!options.afterMkdirp) || (options.afterMkdirp <= 100))) {
-      mkdirp(dirname(path2), function (e) {
+      return mkdirp(path2, function (e) {
         if (e) {
           return callback(e);
         }
         options.afterMkdirp = options.afterMkdirp ? (options.afterMkdirp + 1) : 1;
         return copy(path1, path2, options, callback);
       });
-      return;
     }
     errorCleanup();
     failed = true;
@@ -86,3 +84,31 @@ var copy = module.exports = function(path1, path2, options, callback) {
     fs.unlink(path2, function(e) { });
   }
 };
+
+// Legacy-compatible, tested implementation of mkdirp without
+// any npm audit vulnerabilities
+
+function mkdirp(dir, callback) {
+  dir = path.resolve(dir);
+  return fs.mkdir(dir, function(err) {
+    if (!err) {
+      return callback(null);
+    }
+    if (err.code === 'EEXIST') {
+      return callback(null);
+    }
+    if (err.code === 'ENOENT') {
+      const newDir = path.dirname(dir);
+      if (newDir === dir) {
+        return callback(err);
+      }
+      return mkdirp(newDir, function(err) {
+        if (err) {
+          return callback(err);
+        }
+        return mkdirp(dir, callback);
+      });
+    }
+    return callback(err);
+  });
+}

--- a/lib/copyFile.js
+++ b/lib/copyFile.js
@@ -53,8 +53,11 @@ const copy = module.exports = function(path1, path2, options, callback) {
     // S3 backend anyway.
 
     if ((e.code === 'ENOENT') && ((!options.afterMkdirp) || (options.afterMkdirp <= 100))) {
-      return mkdirp(path2, function (e) {
+      return mkdirp(path.dirname(path2), function (e) {
         if (e) {
+          if (failed) {
+            return;
+          }
           return callback(e);
         }
         options.afterMkdirp = options.afterMkdirp ? (options.afterMkdirp + 1) : 1;

--- a/lib/storage/gcs.js
+++ b/lib/storage/gcs.js
@@ -7,6 +7,7 @@ var storage = require('@google-cloud/storage');
 var extname = require('path').extname;
 var _ = require('lodash');
 var utils = require('../utils');
+var path = require('path');
 
 module.exports = function() {
   let contentTypes;
@@ -54,7 +55,7 @@ module.exports = function() {
       // See https://cloud.google.com/docs/authentication/getting-started
       client = new storage.Storage();
       bucketName = options.bucket;
-      defaultTypes = require(__dirname + '/contentTypes.js');
+      defaultTypes = require(path.join(__dirname, '/contentTypes.js'));
       if (options.contentTypes) {
         _.extend(contentTypes, defaultTypes, options.contentTypes);
       } else {

--- a/lib/storage/gcs.js
+++ b/lib/storage/gcs.js
@@ -92,10 +92,7 @@ module.exports = function() {
         }
       };
       const bucket = client.bucket(bucketName);
-      return bucket.upload(localPath, uploadOptions, function(err) {
-        console.log(`** END of copyIn for ${localPath} ${path}`);
-        return callback(err);
-      });
+      return bucket.upload(localPath, uploadOptions, callback);
     },
 
     copyOut: function(path, localPath, options, callback) {

--- a/lib/storage/gcs.js
+++ b/lib/storage/gcs.js
@@ -92,7 +92,10 @@ module.exports = function() {
         }
       };
       const bucket = client.bucket(bucketName);
-      bucket.upload(localPath, uploadOptions, callback);
+      return bucket.upload(localPath, uploadOptions, function(err) {
+        console.log(`** END of copyIn for ${localPath} ${path}`);
+        return callback(err);
+      });
     },
 
     copyOut: function(path, localPath, options, callback) {

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "xml2js": "^0.4.23"
   },
   "optionalDependencies": {
-    "azure-storage": "^2.8.2",
     "@google-cloud/storage": "^5.3.0",
-    "aws-sdk": "^2.645.0"
+    "aws-sdk": "^2.645.0",
+    "azure-storage": "^2.8.2"
   },
   "devDependencies": {
     "eslint": "^7.26.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "xml2js": "^0.4.23"
   },
   "optionalDependencies": {
-    "@azure/storage-blob": "^12.5.0",
+    "azure-storage": "^2.8.2",
     "@google-cloud/storage": "^5.3.0",
     "aws-sdk": "^2.645.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uploadfs",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "description": "Store files in a web-accessible location via a simplified API. Can automatically scale and rotate images. Includes S3, Azure and local filesystem-based backends with the most convenient features of each.",
   "main": "uploadfs.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,21 +28,20 @@
     "gm": "^1.9.0",
     "gzipme": "^0.1.1",
     "jimp": "^0.9.6",
-    "lodash": "^4.0.0",
-    "mkdirp": "~0.3.4",
+    "lodash": "^4.17.21",
     "request": "^2.88.2",
     "rimraf": "^2.0.2",
     "xml2js": "^0.4.23"
   },
   "optionalDependencies": {
+    "@azure/storage-blob": "^12.5.0",
     "@google-cloud/storage": "^5.3.0",
-    "aws-sdk": "^2.645.0",
-    "azure-storage": "^2.8.2"
+    "aws-sdk": "^2.645.0"
   },
   "devDependencies": {
-    "eslint": "^7.8.0",
+    "eslint": "^7.26.0",
     "eslint-config-apostrophe": "^3.4.0",
-    "mocha": "^5.1.1",
+    "mocha": "^8.4.0",
     "request-promise": "^4.2.5",
     "stat-mode": "^0.2.2"
   }

--- a/sample.js
+++ b/sample.js
@@ -6,16 +6,17 @@ var express = require('express');
 var uploadfs = require('uploadfs')();
 var multipart = require('connect-multiparty');
 var multipartMiddleware = multipart();
+var path = require('path');
 
 // For the local backend
-var uploadsPath = __dirname + '/public/uploads';
+var uploadsPath = path.join(__dirname, '/public/uploads');
 var uploadsLocalUrl = '/uploads';
 var options = {
   backend: 'local',
   uploadsPath: uploadsPath,
   uploadsUrl: 'http://localhost:3000' + uploadsLocalUrl,
   // Required if you use imageSizes and copyImageIn
-  tempPath: __dirname + '/temp',
+  tempPath: path.join(__dirname, '/temp'),
   imageSizes: [
     {
       name: 'small',

--- a/test-imagecrunch.js
+++ b/test-imagecrunch.js
@@ -1,5 +1,6 @@
 var uploadfs = require('./uploadfs.js')();
 var fs = require('fs');
+var path = require('path');
 var _ = require('lodash');
 
 // Test the imagecrunch image backend, written specifically for Macs
@@ -7,7 +8,7 @@ var _ = require('lodash');
 var localOptions = {
   storage: 'local',
   local: 'imagecrunch',
-  uploadsPath: __dirname + '/test',
+  uploadsPath: path.join(__dirname, '/test'),
   uploadsUrl: 'http://localhost:3000/test'
 };
 
@@ -29,7 +30,7 @@ var imageSizes = [
   }
 ];
 
-var tempPath = __dirname + '/temp';
+var tempPath = path.join(__dirname, '/temp');
 
 localOptions.imageSizes = imageSizes;
 localOptions.tempPath = tempPath;

--- a/test-imagemagick.js
+++ b/test-imagemagick.js
@@ -3,13 +3,14 @@ var fs = require('fs');
 var async = require('async');
 var Promise = require('bluebird');
 var _ = require('lodash');
+var path = require('path');
 
 // Test the imagecrunch image backend, written specifically for Macs
 
 var localOptions = {
   storage: 'local',
   image: 'imagemagick',
-  uploadsPath: __dirname + '/test',
+  uploadsPath: path.join(__dirname, '/test'),
   uploadsUrl: 'http://localhost:3000/test'
 };
 
@@ -31,7 +32,7 @@ var imageSizes = [
   }
 ];
 
-var tempPath = __dirname + '/temp';
+var tempPath = path.join(__dirname, '/temp');
 var basePath = '/images/profiles/me';
 
 localOptions.imageSizes = imageSizes;

--- a/test/azure.js
+++ b/test/azure.js
@@ -8,7 +8,7 @@ var uploadfs = require('../uploadfs.js')();
 var srcFile = process.env.AZURE_TEST_FILE || 'test.txt';
 var infilePath = 'one/two/three/';
 var infile = infilePath + srcFile;
-var _ = require('underscore');
+var _ = require('lodash');
 
 /* helper to automate scraping files from blob svc */
 var _getOutfile = function(infile, done) {

--- a/test/local.js
+++ b/test/local.js
@@ -1,16 +1,17 @@
 /* global describe, it */
 var Mode = require('stat-mode');
 var assert = require('assert');
+var path = require('path');
 
 describe('UploadFS Local', function () {
   this.timeout(4500);
   var uploadfs = require('../uploadfs.js')();
   var fs = require('fs');
   var async = require('async');
-  var tempPath = __dirname + '/temp';
+  var tempPath = path.join(__dirname, '/temp');
   var localOptions = {
     storage: 'local',
-    uploadsPath: __dirname + '/files/',
+    uploadsPath: path.join(__dirname, '/files/'),
     uploadsUrl: 'http://localhost:3000/test/'
   };
   var imageSizes = [

--- a/test/s3.js
+++ b/test/s3.js
@@ -201,7 +201,7 @@ describe('UploadFS S3', function () {
         height: 120
       }
     ];
-  
+
     uploadfs.copyImageIn('test.jpg', imgDstPath, { sizes: customSizes }, (e, info) => {
       assert(!e, 'S3 copyImageIn works');
 

--- a/uploadfs.js
+++ b/uploadfs.js
@@ -373,14 +373,16 @@ function Uploadfs() {
       if (context.tempFolder) {
         rmRf(context.tempFolder, function (e) { });
       }
-      callback(err, err ? null : {
-        basePath: context.basePath,
-        extension: context.extension,
-        width: context.info.width,
-        height: context.info.height,
-        originalWidth: context.info.originalWidth,
-        originalHeight: context.info.originalHeight
-      });
+      callback(err, err
+        ? null
+        : {
+          basePath: context.basePath,
+          extension: context.extension,
+          width: context.info.width,
+          height: context.info.height,
+          originalWidth: context.info.originalWidth,
+          originalHeight: context.info.originalHeight
+        });
     });
   };
 


### PR DESCRIPTION
A fixed release of azure-storage is expected within 2 weeks and our semver rules will pick it up automatically.

There is a custom reimplementation of `mkdirp` here because of the need for node 8 bc.

Other changes made resolve issues that mocha 8 detected involving double callbacks, and eslint concerns.