### PR TITLE
npm audit fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+* Bump to next major version of google cloud storage API to please `npm audit`. There was no actual security vulnerability due to the way the module in question was actually used.
+* Update our eslint configuration.
+* Modernize the source from `var` to `const` and `let` in all cases to satisfy eslint and help prevent future bugs. This does not change the behavior of the code.
+
 ## 1.22.1 2023-05-03
 
 * Corrected behavior of `getUrl` method for Azure storage, for Apostrophe compatibility. This regression was introduced an hour ago in 1.22.0.
@@ -327,9 +333,9 @@ Starting in version 0.3.0, you must explicitly create an instance of uploadfs. T
 Existing code that isn't concerned with sharing uploadfs between multiple modules will only need a two line change to be fully compatible:
 
     // CHANGE THIS
-    var uploadfs = require('uploadfs');
+    const uploadfs = require('uploadfs');
 
     // TO THIS (note the extra parens)
-    var uploadfs = require('uploadfs')();
+    const uploadfs = require('uploadfs')();
 
 If you use uploadfs in multiple source code files, you'll need to pass your `uploadfs` object explicitly, much as you pass your Express `app` object when you want to add routes to it via another file.

--- a/lib/image/imagemagick.js
+++ b/lib/image/imagemagick.js
@@ -4,14 +4,14 @@
 // works in Heroku. It's a good thing we can do this, since node-imagemagick
 // has been abandoned. We also use our own custom command lines for
 // drastically better performance and memory usage.
-var im = require('gm').subClass({ imageMagick: true });
-var childProcess = require('child_process');
-var _ = require('lodash');
-var async = require('async');
+const im = require('gm').subClass({ imageMagick: true });
+const childProcess = require('child_process');
+const _ = require('lodash');
+const async = require('async');
 
 module.exports = function() {
-  var options;
-  var self = {
+  let options;
+  const self = {
     /**
      * Initialize the module. If _options.gifsicle is true, use gifsicle to manipulate
      * animated GIFs
@@ -61,7 +61,7 @@ module.exports = function() {
       // an animated GIF is found, which the convert method uses to
       // figure out that it must use a slower algorithm
 
-      var info;
+      let info;
 
       return async.series({
         identify: function(callback) {
@@ -88,8 +88,8 @@ module.exports = function() {
 
             info.originalWidth = info.width;
             info.originalHeight = info.height;
-            var o = info.orientation;
-            var t;
+            const o = info.orientation;
+            let t;
             if ((o === 'LeftTop') || (o === 'RightTop') || (o === 'RightBottom') || (o === 'LeftBottom')) {
               t = info.width;
               info.width = info.height;
@@ -111,7 +111,7 @@ module.exports = function() {
             if (error) {
               return callback(error);
             }
-            var frames = parseInt(stdout.toString('utf8'), 10);
+            const frames = parseInt(stdout.toString('utf8'), 10);
             if (frames > 1) {
               info.animated = true;
             }
@@ -192,9 +192,9 @@ module.exports = function() {
       // bigger and doesn't resize quite as well. Tradeoffs are part of life
 
       function convertAnimatedGifsicle(context, callback) {
-        var crop = context.crop;
-        var imageSizes = context.sizes;
-        var baseArgs = [];
+        const crop = context.crop;
+        const imageSizes = context.sizes;
+        const baseArgs = [];
         if (crop) {
           baseArgs.push('--crop');
           baseArgs.push(crop.left + ',' + crop.top + '+' + crop.width + 'x' + crop.height);
@@ -205,9 +205,9 @@ module.exports = function() {
           if (!context.copyOriginal) {
             return setImmediate(callback);
           }
-          var path = context.tempFolder + '/original.' + context.extension;
+          const path = context.tempFolder + '/original.' + context.extension;
           context.adjustedOriginal = path;
-          var args = baseArgs.slice();
+          const args = baseArgs.slice();
           args.push('--optimize');
           args.push('-o');
           args.push(path);
@@ -217,13 +217,13 @@ module.exports = function() {
           return async.eachSeries(imageSizes, convertSize, callback);
         }
         function convertSize(size, callback) {
-          var args = baseArgs.slice();
+          const args = baseArgs.slice();
           args.push('--resize');
           // "Largest that fits in the box" is not a built-in feature of gifsicle, so we do the math
-          var originalWidth = (crop && crop.width) || context.info.width;
-          var originalHeight = (crop && crop.height) || context.info.height;
-          var width = originalWidth;
-          var height = Math.round(size.width * originalHeight / originalWidth);
+          const originalWidth = (crop && crop.width) || context.info.width;
+          const originalHeight = (crop && crop.height) || context.info.height;
+          let width = originalWidth;
+          let height = Math.round(size.width * originalHeight / originalWidth);
           if (height > originalHeight) {
             height = size.height;
             width = Math.round(size.height * originalWidth / originalHeight);
@@ -231,8 +231,8 @@ module.exports = function() {
           args.push(width + 'x' + height);
           args.push('--optimize');
           args.push('-o');
-          var suffix = size.name + '.' + context.extension;
-          var tempFile = context.tempFolder + '/' + suffix;
+          const suffix = size.name + '.' + context.extension;
+          const tempFile = context.tempFolder + '/' + suffix;
           args.push(tempFile);
           return spawnThen('gifsicle', args, callback);
         }
@@ -245,9 +245,9 @@ module.exports = function() {
       // This is why we don't just rely on -clone 0--1 and a single pipeline. -Tom
 
       function convertAnimated(context, callback) {
-        var crop = context.crop;
-        var imageSizes = context.sizes;
-        var baseArgs = [];
+        const crop = context.crop;
+        const imageSizes = context.sizes;
+        const baseArgs = [];
         baseArgs.push(context.workingPath);
         // Convert to filmstrip so cropping and resizing
         // don't behave strangely
@@ -263,9 +263,9 @@ module.exports = function() {
           if (!context.copyOriginal) {
             return setImmediate(callback);
           }
-          var path = context.tempFolder + '/original.' + context.extension;
+          const path = context.tempFolder + '/original.' + context.extension;
           context.adjustedOriginal = path;
-          var args = baseArgs.slice();
+          const args = baseArgs.slice();
           args.push('-layers');
           args.push('Optimize');
           args.push(path);
@@ -275,13 +275,13 @@ module.exports = function() {
           return async.eachSeries(imageSizes, convertSize, callback);
         }
         function convertSize(size, callback) {
-          var args = baseArgs.slice();
+          const args = baseArgs.slice();
           args.push('-resize');
           args.push(size.width + 'x' + size.height + '>');
           args.push('-layers');
           args.push('Optimize');
-          var suffix = size.name + '.' + context.extension;
-          var tempFile = context.tempFolder + '/' + suffix;
+          const suffix = size.name + '.' + context.extension;
+          const tempFile = context.tempFolder + '/' + suffix;
           args.push(tempFile);
           return spawnThen('convert', args, callback);
         }
@@ -293,9 +293,9 @@ module.exports = function() {
         // size we really want first and use that as a basis for all others, without
         // any lossy intermediate files, which is an even bigger win.
         //
-        var args = [];
-        var crop = context.crop;
-        var imageSizes = context.sizes;
+        const args = [];
+        const crop = context.crop;
+        const imageSizes = context.sizes;
         args.push(context.workingPath);
         args.push('-auto-orient');
         if (crop) {
@@ -331,8 +331,8 @@ module.exports = function() {
         // do it all inside imagemagick without creating any intermediate
         // lossy files, there is no quality loss, and the speed benefit is
         // yet another 2x win! Hooray!
-        var maxWidth = 0;
-        var maxHeight = 0;
+        let maxWidth = 0;
+        let maxHeight = 0;
         _.each(imageSizes, function(size) {
           if (size.width > maxWidth) {
             maxWidth = size.width;
@@ -346,7 +346,7 @@ module.exports = function() {
           args.push(maxWidth + 'x' + maxHeight + '>');
         }
 
-        var resizedPaths = [];
+        const resizedPaths = [];
 
         _.each(imageSizes, function(size) {
           args.push('(');
@@ -359,8 +359,8 @@ module.exports = function() {
             args.push(context.scaledJpegQuality);
           }
           args.push('-write');
-          var suffix = size.name + '.' + context.extension;
-          var tempFile = context.tempFolder + '/' + suffix;
+          const suffix = size.name + '.' + context.extension;
+          const tempFile = context.tempFolder + '/' + suffix;
           resizedPaths.push(tempFile);
           args.push(tempFile);
           args.push('+delete');

--- a/lib/image/sharp.js
+++ b/lib/image/sharp.js
@@ -147,15 +147,15 @@ module.exports = function () {
             const height = Math.min(size.height, context.info.height);
             const sizePipeline = pipeline.clone();
             sizePipeline.resize({
-              width: width,
-              height: height,
+              width,
+              height,
               fit: 'inside'
             });
             if (context.extension === 'jpg') {
               const quality = context.scaledJpegQuality
                 ? context.scaledJpegQuality
                 : 80;
-              sizePipeline.jpeg({ quality: quality });
+              sizePipeline.jpeg({ quality });
             }
             await sizePipeline.toFile(sizePath);
           })

--- a/lib/storage/azure.js
+++ b/lib/storage/azure.js
@@ -1,16 +1,16 @@
-var { BlobServiceClient, StorageSharedKeyCredential } = require('@azure/storage-blob');
-var contentTypes = require('./contentTypes');
-var extname = require('path').extname;
-var fs = require('fs');
-var zlib = require('zlib');
-var async = require('async');
-var utils = require('../utils.js');
-var defaultGzipBlacklist = require('../../defaultGzipBlacklist');
-var verbose = false;
-var _ = require('lodash');
+const { BlobServiceClient, StorageSharedKeyCredential } = require('@azure/storage-blob');
+const contentTypes = require('./contentTypes');
+const extname = require('path').extname;
+const fs = require('fs');
+const zlib = require('zlib');
+const async = require('async');
+const utils = require('../utils.js');
+const defaultGzipBlacklist = require('../../defaultGzipBlacklist');
+const verbose = false;
+const _ = require('lodash');
 
-var DEFAULT_MAX_AGE_IN_SECONDS = 500;
-var DEFAULT_MAX_CACHE = 2628000;
+const DEFAULT_MAX_AGE_IN_SECONDS = 500;
+const DEFAULT_MAX_CACHE = 2628000;
 
 /**
  * @typedef {{ svc: BlobServiceClient, container: string }} BlobSvc
@@ -60,20 +60,20 @@ function setContainerProperties(blobSvc, options, result, callback) {
       if (response.errorCode) {
         return callback(response.errorCode);
       }
-      var serviceProperties = response;
-      var allowedOrigins = propToString(options.allowedOrigins) || '*';
-      var allowedMethods = propToString(options.allowedMethods) || 'GET,PUT,POST';
-      var allowedHeaders = propToString(options.allowedHeaders) || '*';
-      var exposedHeaders = propToString(options.exposedHeaders) || '*';
-      var maxAgeInSeconds = options.maxAgeInSeconds || DEFAULT_MAX_AGE_IN_SECONDS;
+      const serviceProperties = response;
+      const allowedOrigins = propToString(options.allowedOrigins) || '*';
+      const allowedMethods = propToString(options.allowedMethods) || 'GET,PUT,POST';
+      const allowedHeaders = propToString(options.allowedHeaders) || '*';
+      const exposedHeaders = propToString(options.exposedHeaders) || '*';
+      const maxAgeInSeconds = options.maxAgeInSeconds || DEFAULT_MAX_AGE_IN_SECONDS;
 
       serviceProperties.cors = [
         {
-          allowedOrigins: allowedOrigins,
-          allowedMethods: allowedMethods,
-          allowedHeaders: allowedHeaders,
-          exposedHeaders: exposedHeaders,
-          maxAgeInSeconds: maxAgeInSeconds
+          allowedOrigins,
+          allowedMethods,
+          allowedHeaders,
+          exposedHeaders,
+          maxAgeInSeconds
         }
       ];
 
@@ -117,12 +117,12 @@ function initializeContainer(blobSvc, container, options, callback) {
  * @return {any} Returns the initialized service
  */
 function createContainer(cluster, options, callback) {
-  var sharedKeyCredential = new StorageSharedKeyCredential(cluster.account, cluster.key);
-  var blobSvc = new BlobServiceClient(
+  const sharedKeyCredential = new StorageSharedKeyCredential(cluster.account, cluster.key);
+  const blobSvc = new BlobServiceClient(
     `https://${cluster.account}.blob.core.windows.net`,
     sharedKeyCredential
   );
-  var container = cluster.container || options.container;
+  const container = cluster.container || options.container;
   blobSvc.uploadfsInfo = {
     account: cluster.account,
     container: options.container || cluster.container
@@ -162,8 +162,8 @@ function createContainerBlob(blob, path, localPath, _gzip, callback) {
   // Draw the extension from uploadfs, where we know they will be using
   // reasonable extensions, not from what could be a temporary file
   // that came from the gzip code. -Tom
-  var extension = extname(path).substring(1);
-  var contentSettings = {
+  const extension = extname(path).substring(1);
+  const contentSettings = {
     cacheControl: `max-age=${DEFAULT_MAX_CACHE}, public`,
     // contentEncoding: _gzip ? 'gzip' : 'deflate',
     contentType: contentTypes[extension] || 'application/octet-stream'
@@ -238,7 +238,7 @@ function clusterError(cluster, err) {
 
 module.exports = function() {
 
-  var self = {
+  const self = {
     blobSvcs: [],
     init: function(options, callback) {
       if (!options.disabledFileKey) {
@@ -262,7 +262,7 @@ module.exports = function() {
           }
 
           self.blobSvcs.push({
-            svc: svc,
+            svc,
             container: cluster.container || options.container
           });
 
@@ -315,9 +315,9 @@ module.exports = function() {
         return callback(new Error('At least one valid container must be included in the replicateCluster configuration.'));
       }
       const fileExt = localPath.split('.').pop();
-      var path = _path[0] === '/' ? _path.slice(1) : _path;
-      var tmpFileName = Math.random().toString(36).substring(7);
-      var tempPath = this.options.tempPath + '/' + tmpFileName;
+      const path = _path[0] === '/' ? _path.slice(1) : _path;
+      const tmpFileName = Math.random().toString(36).substring(7);
+      let tempPath = this.options.tempPath + '/' + tmpFileName;
       // options optional
       if (!callback) {
         callback = options;
@@ -342,9 +342,9 @@ module.exports = function() {
     },
 
     doGzip: function(localPath, path, tempPath, callback) {
-      var inp = fs.createReadStream(localPath);
-      var out = fs.createWriteStream(tempPath);
-      var hasError = false;
+      const inp = fs.createReadStream(localPath);
+      const out = fs.createWriteStream(tempPath);
+      let hasError = false;
 
       inp.on('error', function(inpErr) {
         __log('Error in read stream', inpErr);
@@ -364,7 +364,7 @@ module.exports = function() {
       out.on('finish', function() {
         self.createContainerBlobs(localPath, path, tempPath, true, callback);
       });
-      var gzip = zlib.createGzip();
+      const gzip = zlib.createGzip();
       inp.pipe(gzip).pipe(out);
     },
 
@@ -377,7 +377,7 @@ module.exports = function() {
       if (!self.blobSvcs.length) {
         return callback(new Error('At least one valid container must be included in the replicateCluster configuration.'));
       }
-      var index = 0;
+      let index = 0;
       return attempt();
 
       function attempt(lastErr) {
@@ -385,10 +385,10 @@ module.exports = function() {
           return callback(clusterError('all', lastErr));
         }
         /** @type {BlobSvc} */
-        var blob = self.blobSvcs[index++];
+        const blob = self.blobSvcs[index++];
         path = path[0] === '/' ? path.slice(1) : path;
         // Temporary name until we know if it is gzipped.
-        var initialPath = localPath + '.initial';
+        const initialPath = localPath + '.initial';
 
         return blob.svc.getContainerClient(blob.container)
           .getBlobClient(path)
@@ -398,9 +398,9 @@ module.exports = function() {
               return attempt(response.errorCode);
             }
             // BC
-            var returnVal = {
+            const returnVal = {
               result: response,
-              response: response
+              response
             };
             if (response.contentEncoding === 'gzip') {
               // Now we know we need to unzip it.
@@ -412,10 +412,10 @@ module.exports = function() {
             }
 
             function gunzipBlob() {
-              var out = fs.createWriteStream(localPath);
-              var inp = fs.createReadStream(initialPath);
-              var gunzip = zlib.createGunzip();
-              var errorSeen = false;
+              const out = fs.createWriteStream(localPath);
+              const inp = fs.createReadStream(initialPath);
+              const gunzip = zlib.createGunzip();
+              let errorSeen = false;
               inp.pipe(gunzip);
               gunzip.pipe(out);
               inp.on('error', function(e) {
@@ -459,7 +459,7 @@ module.exports = function() {
       if (!self.blobSvcs.length) {
         return callback(new Error('At least one valid container must be included in the replicateCluster configuration.'));
       }
-      var dPath = utils.getDisabledPath(path, self.options.disabledFileKey);
+      const dPath = utils.getDisabledPath(path, self.options.disabledFileKey);
       async.each(self.blobSvcs, function(blob, callback) {
         copyBlob(blob, path, dPath, function(e) {
           // if copy fails, abort
@@ -478,7 +478,7 @@ module.exports = function() {
       if (!self.blobSvcs.length) {
         return callback(new Error('At least one valid container must be included in the replicateCluster configuration.'));
       }
-      var dPath = utils.getDisabledPath(path, self.options.disabledFileKey);
+      const dPath = utils.getDisabledPath(path, self.options.disabledFileKey);
       async.each(self.blobSvcs, function(blob, callback) {
         copyBlob(blob, dPath, path, function(e) {
           if (e) {
@@ -494,7 +494,7 @@ module.exports = function() {
 
     getUrl: function (path) {
       /** @type {BlobSvc} */
-      var blob = self.blobSvcs[0];
+      const blob = self.blobSvcs[0];
       const baseUrl = blob.svc.getContainerClient(blob.container)
         .getBlobClient('')
         .url
@@ -513,8 +513,8 @@ module.exports = function() {
      * @retyrb {Array} An array of file extensions to ignore
      */
     getGzipBlacklist: function(gzipEncoding) {
-      var gzipSettings = gzipEncoding || {};
-      var { whitelist, blacklist } = Object.keys(gzipSettings).reduce((prev, key) => {
+      const gzipSettings = gzipEncoding || {};
+      const { whitelist, blacklist } = Object.keys(gzipSettings).reduce((prev, key) => {
         if (gzipSettings[key]) {
           prev.whitelist.push(key);
         } else {
@@ -527,7 +527,7 @@ module.exports = function() {
       });
 
       // @NOTE - we REMOVE whitelisted types from the blacklist array
-      var gzipBlacklist = defaultGzipBlacklist.concat(blacklist).filter(el => whitelist.indexOf(el));
+      const gzipBlacklist = defaultGzipBlacklist.concat(blacklist).filter(el => whitelist.indexOf(el));
 
       return _.uniq(gzipBlacklist);
     }

--- a/lib/storage/gcs.js
+++ b/lib/storage/gcs.js
@@ -3,11 +3,11 @@
 // Google Cloud Storage backend for uploadfs. See also
 // local.js.
 
-var storage = require('@google-cloud/storage');
-var extname = require('path').extname;
-var _ = require('lodash');
-var utils = require('../utils');
-var path = require('path');
+const storage = require('@google-cloud/storage');
+const extname = require('path').extname;
+const _ = require('lodash');
+const utils = require('../utils');
+const path = require('path');
 
 module.exports = function() {
   let contentTypes;
@@ -33,10 +33,10 @@ module.exports = function() {
       if (options.endpoint) {
         endpoint = options.endpoint;
         if (!endpoint.match(/^https?:/)) {
-          var defaultSecure = ((!options.port) || (options.port === 443));
-          var secure = options.secure || defaultSecure;
-          var port = options.port || 443;
-          var protocol = secure ? 'https://' : 'http://';
+          const defaultSecure = ((!options.port) || (options.port === 443));
+          const secure = options.secure || defaultSecure;
+          let port = options.port || 443;
+          const protocol = secure ? 'https://' : 'http://';
           if (secure && (port === 443)) {
             port = '';
           } else if ((!secure) && (port === 80)) {
@@ -86,9 +86,9 @@ module.exports = function() {
         destination: path,
         gzip: true,
         public: true,
-        validation: validation,
+        validation,
         metadata: {
-          cacheControl: cacheControl,
+          cacheControl,
           ContentType: contentType
         }
       };
@@ -100,7 +100,7 @@ module.exports = function() {
       path = utils.removeLeadingSlash(self.options, path);
       const mergedOptions = _.assign({
         destination: localPath,
-        validation: validation
+        validation
       }, options);
       client.bucket(bucketName).file(path).download(mergedOptions, callback);
     },

--- a/lib/storage/local.js
+++ b/lib/storage/local.js
@@ -7,19 +7,19 @@
 // and it encourages you to write code that will still work
 // when you switch to the s3 backend
 
-var dirname = require('path').dirname;
-var fs = require('fs');
-var copyFile = require('../copyFile.js');
-var async = require('async');
-var utils = require('../utils.js');
+const dirname = require('path').dirname;
+const fs = require('fs');
+const copyFile = require('../copyFile.js');
+const async = require('async');
+const utils = require('../utils.js');
 
 module.exports = function() {
-  var uploadsPath;
-  var uploadsUrl;
-  var removeCandidates = [];
-  var timeout;
+  let uploadsPath;
+  let uploadsUrl;
+  let removeCandidates = [];
+  let timeout;
 
-  var self = {
+  const self = {
     init: function(options, callback) {
       self.options = options;
       uploadsPath = options.uploadsPath;
@@ -37,7 +37,7 @@ module.exports = function() {
 
       function cleanup() {
         timeout = null;
-        var list = removeCandidates;
+        const list = removeCandidates;
         // Longest paths first, so we don't try to remove parents before children
         // and wind up never getting rid of the parent
         list.sort(function(a, b) {
@@ -54,7 +54,7 @@ module.exports = function() {
         // Parallelism here just removes things too soon preventing a parent from being removed
         // after a child
         return async.eachSeries(list, function(path, callback) {
-          var uploadPath = uploadsPath + path;
+          const uploadPath = uploadsPath + path;
           fs.rmdir(uploadPath, function(e) {
             // We're not fussy about the outcome, if it still has files in it we're
             // actually depending on this to fail
@@ -90,17 +90,17 @@ module.exports = function() {
     },
 
     copyIn: function(localPath, path, options, callback) {
-      var uploadPath = uploadsPath + path;
+      const uploadPath = uploadsPath + path;
       return copyFile(localPath, uploadPath, callback);
     },
 
     copyOut: function(path, localPath, options, callback) {
-      var downloadPath = uploadsPath + path;
+      const downloadPath = uploadsPath + path;
       return copyFile(downloadPath, localPath, callback);
     },
 
     remove: function(path, callback) {
-      var uploadPath = uploadsPath + path;
+      const uploadPath = uploadsPath + path;
       fs.unlink(uploadPath, callback);
       if (dirname(path).length > 1) {
         removeCandidates.push(dirname(path));
@@ -144,7 +144,7 @@ module.exports = function() {
       if (!self.options.disabledFileKey) {
         return callback(new Error('migrateToDisabledFileKey invoked with no disabledFileKey option set.'));
       }
-      var candidates = [];
+      const candidates = [];
       try {
         spelunk('');
       } catch (e) {
@@ -155,10 +155,10 @@ module.exports = function() {
         self.disable(file, callback);
       }, callback);
       function spelunk(folder) {
-        var files = fs.readdirSync(uploadsPath + folder);
+        const files = fs.readdirSync(uploadsPath + folder);
         files.forEach(function(file) {
-          var stats = fs.statSync(uploadsPath + folder + '/' + file);
-          var mode = stats.mode & parseInt('0777', 8);
+          const stats = fs.statSync(uploadsPath + folder + '/' + file);
+          const mode = stats.mode & parseInt('0777', 8);
           if (stats.isDirectory()) {
             return spelunk(folder + '/' + file);
           }
@@ -173,7 +173,7 @@ module.exports = function() {
       if (self.options.disabledFileKey) {
         return callback('migrateFromDisabledFileKey invoked with disabledFileKey option still set.');
       }
-      var candidates = [];
+      const candidates = [];
       try {
         spelunk('');
       } catch (e) {
@@ -193,9 +193,9 @@ module.exports = function() {
         }
       }, callback);
       function spelunk(folder) {
-        var files = fs.readdirSync(uploadsPath + folder);
+        const files = fs.readdirSync(uploadsPath + folder);
         files.forEach(function(file) {
-          var stats = fs.statSync(uploadsPath + folder + '/' + file);
+          const stats = fs.statSync(uploadsPath + folder + '/' + file);
           if (stats.isDirectory()) {
             return spelunk(folder + '/' + file);
           }

--- a/lib/storage/s3.js
+++ b/lib/storage/s3.js
@@ -3,26 +3,26 @@
 // Amazon s3-based backend for uploadfs. See also
 // local.js.
 
-var fs = require('fs');
-var AWS = require('aws-sdk');
-var extname = require('path').extname;
-var _ = require('lodash');
+const fs = require('fs');
+const AWS = require('aws-sdk');
+const extname = require('path').extname;
+const _ = require('lodash');
 const utils = require('../utils');
 
 module.exports = function() {
-  var contentTypes;
-  var client;
-  var cachingTime;
-  var https;
-  var bucket;
-  var bucketObjectsACL;
-  var endpoint;
-  var defaultTypes;
-  var noProtoEndpoint;
-  var pathStyle;
-  var noGzipContentTypes;
-  var addNoGzipContentTypes;
-  var self = {
+  let contentTypes;
+  let client;
+  let cachingTime;
+  let https;
+  let bucket;
+  let bucketObjectsACL;
+  let endpoint;
+  let defaultTypes;
+  let noProtoEndpoint;
+  let pathStyle;
+  let noGzipContentTypes;
+  let addNoGzipContentTypes;
+  const self = {
     init: function (options, callback) {
       // knox bc
       endpoint = 's3.amazonaws.com';
@@ -40,10 +40,10 @@ module.exports = function() {
         endpoint = options.endpoint;
         if (!endpoint.match(/^https?:/)) {
           // Infer it like knox would
-          var defaultSecure = ((!options.port) || (options.port === 443));
-          var secure = options.secure || defaultSecure;
-          var port = options.port || 443;
-          var protocol = secure ? 'https://' : 'http://';
+          const defaultSecure = ((!options.port) || (options.port === 443));
+          const secure = options.secure || defaultSecure;
+          let port = options.port || 443;
+          const protocol = secure ? 'https://' : 'http://';
           if (secure && (port === 443)) {
             port = '';
           } else if ((!secure) && (port === 80)) {
@@ -82,18 +82,18 @@ module.exports = function() {
     },
 
     copyIn: function(localPath, path, options, callback) {
-      var ext = extname(path);
+      let ext = extname(path);
       if (ext.length) {
         ext = ext.substr(1);
       }
-      var contentType = contentTypes[ext];
+      let contentType = contentTypes[ext];
       if (!contentType) {
         contentType = 'application/octet-stream';
       }
 
-      var inputStream = fs.createReadStream(localPath);
+      const inputStream = fs.createReadStream(localPath);
 
-      var params = {
+      const params = {
         ACL: bucketObjectsACL,
         Key: utils.removeLeadingSlash(self.options, path),
         Body: inputStream,
@@ -102,7 +102,7 @@ module.exports = function() {
 
       if (gzipAppropriate(contentType)) {
         params.ContentEncoding = 'gzip';
-        var gzip = require('zlib').createGzip();
+        const gzip = require('zlib').createGzip();
         inputStream.pipe(gzip);
         params.Body = gzip;
       }
@@ -119,16 +119,16 @@ module.exports = function() {
     },
 
     copyOut: function(path, localPath, options, callback) {
-      var finished = false;
-      var outputStream = fs.createWriteStream(localPath);
-      var params = {
+      let finished = false;
+      const outputStream = fs.createWriteStream(localPath);
+      const params = {
         Key: utils.removeLeadingSlash(self.options, path)
       };
-      var request = client.getObject(params);
-      var inputStream = request.createReadStream();
+      const request = client.getObject(params);
+      let inputStream = request.createReadStream();
       request.on('httpHeaders', function(status, headers) {
         if (headers['content-encoding'] === 'gzip') {
-          var gunzip = require('zlib').createGunzip();
+          const gunzip = require('zlib').createGunzip();
           inputStream.pipe(gunzip);
           inputStream = gunzip;
         }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,4 @@
-var crypto = require('crypto');
+const crypto = require('crypto');
 /**
  * Helper functions
  **/
@@ -11,9 +11,9 @@ module.exports = {
   // one such filename is exposed, the others remain secure
 
   getDisabledPath: function(path, disabledFileKey) {
-    var hmac = crypto.createHmac('sha256', disabledFileKey);
+    const hmac = crypto.createHmac('sha256', disabledFileKey);
     hmac.update(path);
-    var disabledPath = path + '-disabled-' + hmac.digest('hex');
+    const disabledPath = path + '-disabled-' + hmac.digest('hex');
     return disabledPath;
   },
 

--- a/package.json
+++ b/package.json
@@ -34,13 +34,13 @@
   },
   "optionalDependencies": {
     "@azure/storage-blob": "^12.14.0",
-    "@google-cloud/storage": "^5.3.0",
+    "@google-cloud/storage": "^6.11.0",
     "aws-sdk": "^2.645.0",
     "sharp": "^0.30.7"
   },
   "devDependencies": {
-    "eslint": "^7.26.0",
-    "eslint-config-apostrophe": "^3.4.0",
+    "eslint": "^8.0.0",
+    "eslint-config-apostrophe": "^4.0.0",
     "mocha": "^10.2.0",
     "node-fetch": "^2.6.9",
     "stat-mode": "^0.2.2"

--- a/sample.js
+++ b/sample.js
@@ -2,18 +2,18 @@
 // and stores them in either a local folder or s3,
 // depending on which backend you choose.
 
-var express = require('express');
-var uploadfs = require('uploadfs')();
-var multipart = require('connect-multiparty');
-var multipartMiddleware = multipart();
-var path = require('path');
+const express = require('express');
+const uploadfs = require('uploadfs')();
+const multipart = require('connect-multiparty');
+const multipartMiddleware = multipart();
+const path = require('path');
 
 // For the local backend
-var uploadsPath = path.join(__dirname, '/public/uploads');
-var uploadsLocalUrl = '/uploads';
-var options = {
+const uploadsPath = path.join(__dirname, '/public/uploads');
+const uploadsLocalUrl = '/uploads';
+const options = {
   backend: 'local',
-  uploadsPath: uploadsPath,
+  uploadsPath,
   uploadsUrl: 'http://localhost:3000' + uploadsLocalUrl,
   // Required if you use imageSizes and copyImageIn
   tempPath: path.join(__dirname, '/temp'),
@@ -43,7 +43,7 @@ function createApp(err) {
     console.log(err);
     process.exit(1);
   }
-  var app = express();
+  const app = express();
 
   // For the local backend: serve the uploaded files at /uploads.
   // With the s3 backend you don't need this of course, s3 serves

--- a/test-imagemagick.js
+++ b/test-imagemagick.js
@@ -1,20 +1,20 @@
-var uploadfs = require('./uploadfs.js')();
-var fs = require('fs');
-var async = require('async');
-var Promise = require('bluebird');
-var _ = require('lodash');
-var path = require('path');
+const uploadfs = require('./uploadfs.js')();
+const fs = require('fs');
+const async = require('async');
+const Promise = require('bluebird');
+const _ = require('lodash');
+const path = require('path');
 
 // Test the imagecrunch image backend, written specifically for Macs
 
-var localOptions = {
+const localOptions = {
   storage: 'local',
   image: 'imagemagick',
   uploadsPath: path.join(__dirname, '/test'),
   uploadsUrl: 'http://localhost:3000/test'
 };
 
-var imageSizes = [
+const imageSizes = [
   {
     name: 'small',
     width: 320,
@@ -32,15 +32,15 @@ var imageSizes = [
   }
 ];
 
-var tempPath = path.join(__dirname, '/temp');
-var basePath = '/images/profiles/me';
+const tempPath = path.join(__dirname, '/temp');
+const basePath = '/images/profiles/me';
 
 localOptions.imageSizes = imageSizes;
 localOptions.tempPath = tempPath;
 localOptions.backend = 'local';
 
 localTestStart(function () {
-  var filesSeen = false;
+  let filesSeen = false;
   console.log('RERUN TESTS WITH TEST OF POSTPROCESSORS');
   localOptions.postprocessors = [
     {
@@ -96,7 +96,7 @@ localTestStart(function () {
 });
 
 function localTestStart(cb) {
-  var options = localOptions;
+  const options = localOptions;
   console.log('Initializing uploadfs for the ' + options.backend + ' storage backend with the imagecrunch image backend');
   uploadfs.init(options, function(e) {
     if (e) {
@@ -138,7 +138,7 @@ function localTestStart(cb) {
         process.exit(1);
       }
 
-      var stats = fs.statSync('test/images/profiles/me.jpg');
+      const stats = fs.statSync('test/images/profiles/me.jpg');
 
       if (!stats.size) {
         console.log('Copied image is empty or missing');
@@ -149,8 +149,8 @@ function localTestStart(cb) {
       console.log('Removing files...');
       uploadfs.remove('/images/profiles/me.jpg', function(e) {
         async.each(imageSizes, function(size, callback) {
-          var name = info.basePath + '.' + size.name + '.jpg';
-          var stats = fs.statSync('test' + name);
+          const name = info.basePath + '.' + size.name + '.jpg';
+          const stats = fs.statSync('test' + name);
           if (!stats.size) {
             console.log('Scaled and copied image is empty or missing (2)');
             process.exit(1);
@@ -203,7 +203,7 @@ function localTestStart(cb) {
         process.exit(1);
       }
 
-      var stats = fs.statSync('test/images/profiles/me-cropped.jpg');
+      const stats = fs.statSync('test/images/profiles/me-cropped.jpg');
 
       if (!stats.size) {
         console.log('Copied image is empty or missing');
@@ -214,8 +214,8 @@ function localTestStart(cb) {
       console.log('Removing files...');
       uploadfs.remove(`${basePath}-cropped.jpg`, function(e) {
         async.each(imageSizes, function(size, callback) {
-          var name = info.basePath + '.' + size.name + '.jpg';
-          var stats = fs.statSync('test' + name);
+          const name = info.basePath + '.' + size.name + '.jpg';
+          const stats = fs.statSync('test' + name);
           if (!stats.size) {
             console.log('Scaled and copied image is empty or missing (2)');
             process.exit(1);

--- a/test-sharp.js
+++ b/test-sharp.js
@@ -1,20 +1,20 @@
-var uploadfs = require('./uploadfs.js')();
-var fs = require('fs');
-var async = require('async');
-var Promise = require('bluebird');
-var _ = require('lodash');
-var path = require('path');
+const uploadfs = require('./uploadfs.js')();
+const fs = require('fs');
+const async = require('async');
+const Promise = require('bluebird');
+const _ = require('lodash');
+const path = require('path');
 
 // Test the imagecrunch image backend, written specifically for Macs
 
-var localOptions = {
+const localOptions = {
   storage: 'local',
   image: 'sharp',
   uploadsPath: path.join(__dirname, '/test'),
   uploadsUrl: 'http://localhost:3000/test'
 };
 
-var imageSizes = [
+const imageSizes = [
   {
     name: 'small',
     width: 320,
@@ -32,15 +32,15 @@ var imageSizes = [
   }
 ];
 
-var tempPath = path.join(__dirname, '/temp');
-var basePath = '/images/profiles/me';
+const tempPath = path.join(__dirname, '/temp');
+const basePath = '/images/profiles/me';
 
 localOptions.imageSizes = imageSizes;
 localOptions.tempPath = tempPath;
 localOptions.backend = 'local';
 
 localTestStart(function () {
-  var filesSeen = false;
+  let filesSeen = false;
   console.log('RERUN TESTS WITH TEST OF POSTPROCESSORS');
   localOptions.postprocessors = [
     {
@@ -96,7 +96,7 @@ localTestStart(function () {
 });
 
 function localTestStart(cb) {
-  var options = localOptions;
+  const options = localOptions;
   console.log('Initializing uploadfs for the ' + options.backend + ' storage backend with the imagecrunch image backend');
   uploadfs.init(options, function(e) {
     if (e) {
@@ -138,7 +138,7 @@ function localTestStart(cb) {
         process.exit(1);
       }
 
-      var stats = fs.statSync('test/images/profiles/me.jpg');
+      const stats = fs.statSync('test/images/profiles/me.jpg');
 
       if (!stats.size) {
         console.log('Copied image is empty or missing');
@@ -149,8 +149,8 @@ function localTestStart(cb) {
       console.log('Removing files...');
       uploadfs.remove('/images/profiles/me.jpg', function(e) {
         async.each(imageSizes, function(size, callback) {
-          var name = info.basePath + '.' + size.name + '.jpg';
-          var stats = fs.statSync('test' + name);
+          const name = info.basePath + '.' + size.name + '.jpg';
+          const stats = fs.statSync('test' + name);
           if (!stats.size) {
             console.log('Scaled and copied image is empty or missing (2)');
             process.exit(1);
@@ -203,7 +203,7 @@ function localTestStart(cb) {
         process.exit(1);
       }
 
-      var stats = fs.statSync('test/images/profiles/me-cropped.jpg');
+      const stats = fs.statSync('test/images/profiles/me-cropped.jpg');
 
       if (!stats.size) {
         console.log('Copied image is empty or missing');
@@ -214,8 +214,8 @@ function localTestStart(cb) {
       console.log('Removing files...');
       uploadfs.remove(`${basePath}-cropped.jpg`, function(e) {
         async.each(imageSizes, function(size, callback) {
-          var name = info.basePath + '.' + size.name + '.jpg';
-          var stats = fs.statSync('test' + name);
+          const name = info.basePath + '.' + size.name + '.jpg';
+          const stats = fs.statSync('test' + name);
           if (!stats.size) {
             console.log('Scaled and copied image is empty or missing (2)');
             process.exit(1);

--- a/test/azure.js
+++ b/test/azure.js
@@ -1,24 +1,24 @@
 /* global describe, it */
-var assert = require('assert');
-var fs = require('fs');
-var fetch = require('node-fetch');
-var uploadfs = require('../uploadfs.js')();
+const assert = require('assert');
+const fs = require('fs');
+const fetch = require('node-fetch');
+const uploadfs = require('../uploadfs.js')();
 // A JPEG is not a good default because it is exempt from GZIP so
 // we get less coverage. -Tom
-var srcFile = process.env.AZURE_TEST_FILE || 'test.txt';
-var infilePath = 'one/two/three/';
-var infile = infilePath + srcFile;
-var _ = require('lodash');
+const srcFile = process.env.AZURE_TEST_FILE || 'test.txt';
+const infilePath = 'one/two/three/';
+const infile = infilePath + srcFile;
+const _ = require('lodash');
 
 /* helper to automate scraping files from blob svc */
-var _getOutfile = function(infile, done) {
-  var tmpFileName = new Date().getTime() + srcFile;
-  var ogFile = fs.readFileSync(srcFile, { encoding: 'utf8' });
+const _getOutfile = function(infile, done) {
+  const tmpFileName = new Date().getTime() + srcFile;
+  const ogFile = fs.readFileSync(srcFile, { encoding: 'utf8' });
 
   return uploadfs.copyOut(infile, tmpFileName, {}, function (e, res) {
     try {
       assert(!e, 'Azure copy out nominal success');
-      var content = fs.readFileSync(tmpFileName, { encoding: 'utf8' });
+      const content = fs.readFileSync(tmpFileName, { encoding: 'utf8' });
       assert(content.length, 'copyOut file has length');
       assert(ogFile.length, 'original file body has length');
       // console.log(ogFile, content);
@@ -34,9 +34,9 @@ var _getOutfile = function(infile, done) {
 describe('UploadFS Azure', function() {
   this.timeout(40000);
 
-  var tempPath = '../temp';
+  const tempPath = '../temp';
 
-  var azureOptions = require('../azureTestOptions.js');
+  const azureOptions = require('../azureTestOptions.js');
   azureOptions.tempPath = tempPath;
 
   it('Should connect to Azure cloud successfully', function(done) {
@@ -154,8 +154,8 @@ describe('UploadFS Azure', function() {
   });
 
   it('Uploadfs should return valid web-servable url pointing to uploaded file', function() {
-    var url = uploadfs.getUrl(infile);
-    var ogFile = fs.readFileSync(srcFile);
+    const url = uploadfs.getUrl(infile);
+    const ogFile = fs.readFileSync(srcFile);
     assert(ogFile.length);
     assert(url);
 
@@ -189,7 +189,7 @@ describe('UploadFS Azure', function() {
   });
 
   it('Azure test copyOut should fail', function(done) {
-    var tmpFileName = new Date().getTime() + '_text.txt';
+    const tmpFileName = new Date().getTime() + '_text.txt';
 
     uploadfs.copyOut(infile, tmpFileName, {}, function (e, res) {
       try {

--- a/test/local.js
+++ b/test/local.js
@@ -1,20 +1,20 @@
 /* global describe, it */
-var Mode = require('stat-mode');
-var assert = require('assert');
-var path = require('path');
+const Mode = require('stat-mode');
+const assert = require('assert');
+const path = require('path');
 
 describe('UploadFS Local', function () {
   this.timeout(4500);
-  var uploadfs = require('../uploadfs.js')();
-  var fs = require('fs');
-  var async = require('async');
-  var tempPath = path.join(__dirname, '/temp');
-  var localOptions = {
+  const uploadfs = require('../uploadfs.js')();
+  const fs = require('fs');
+  const async = require('async');
+  const tempPath = path.join(__dirname, '/temp');
+  const localOptions = {
     storage: 'local',
     uploadsPath: path.join(__dirname, '/files/'),
     uploadsUrl: 'http://localhost:3000/test/'
   };
-  var imageSizes = [
+  const imageSizes = [
     {
       name: 'small',
       width: 320,
@@ -45,8 +45,8 @@ describe('UploadFS Local', function () {
   it('copyIn should work for local filesystem', done => {
     return uploadfs.copyIn('./test.txt', '/test_copy.txt', e => {
       assert(!e);
-      var og = fs.readFileSync('./test.txt', 'utf8');
-      var next = fs.readFileSync('./test/files/test_copy.txt', 'utf8');
+      const og = fs.readFileSync('./test.txt', 'utf8');
+      const next = fs.readFileSync('./test/files/test_copy.txt', 'utf8');
       assert(og.length, 'lengthy');
       assert(next.length, 'lengthy');
       assert(og === next, 'Copies are equal');
@@ -57,8 +57,8 @@ describe('UploadFS Local', function () {
   it('copyOut should work for local filesystem', done => {
     return uploadfs.copyOut('/test_copy.txt', 'copy-out-test.txt', e => {
       assert(!e);
-      var og = fs.readFileSync('./test.txt', 'utf8');
-      var next = fs.readFileSync('./copy-out-test.txt', 'utf8');
+      const og = fs.readFileSync('./test.txt', 'utf8');
+      const next = fs.readFileSync('./copy-out-test.txt', 'utf8');
       assert(og.length, 'lengthy');
       assert(next.length, 'lengthy');
       assert(og === next, 'Copied files are equal');
@@ -69,8 +69,8 @@ describe('UploadFS Local', function () {
   it('overwrite with copyIn should work for local filesystem', done => {
     return uploadfs.copyIn('./test2.txt', '/test_copy.txt', e => {
       assert(!e);
-      var og = fs.readFileSync('./test2.txt', 'utf8');
-      var next = fs.readFileSync('./test/files/test_copy.txt', 'utf8');
+      const og = fs.readFileSync('./test2.txt', 'utf8');
+      const next = fs.readFileSync('./test/files/test_copy.txt', 'utf8');
       assert(og.length, 'lengthy');
       assert(next.length, 'lengthy');
       assert(og === next, 'Copies are equal');
@@ -81,8 +81,8 @@ describe('UploadFS Local', function () {
   it('copyOut should see update for local filesystem', done => {
     return uploadfs.copyOut('/test_copy.txt', 'copy-out-test.txt', e => {
       assert(!e);
-      var og = fs.readFileSync('./test2.txt', 'utf8');
-      var next = fs.readFileSync('./copy-out-test.txt', 'utf8');
+      const og = fs.readFileSync('./test2.txt', 'utf8');
+      const next = fs.readFileSync('./copy-out-test.txt', 'utf8');
       assert(og.length, 'lengthy');
       assert(next.length, 'lengthy');
       assert(og === next, 'Copied files are equal');
@@ -91,16 +91,16 @@ describe('UploadFS Local', function () {
   });
 
   it('Test disable / enable functionality', done => {
-    var srcFile = '/test_copy.txt';
-    var infile = './test/files/test_copy.txt';
+    const srcFile = '/test_copy.txt';
+    const infile = './test/files/test_copy.txt';
 
     return async.series({
       disable: cb => {
         assert(fs.existsSync(infile), 'copyIn file exissts');
 
         uploadfs.disable(srcFile, e => {
-          var stats = fs.statSync(infile);
-          var mode = new Mode(stats);
+          const stats = fs.statSync(infile);
+          const mode = new Mode(stats);
           assert(!e, 'uploadfs disable success!');
           assert(mode.toString() === '----------', 'File permissions locked down');
           return cb(null);
@@ -108,8 +108,8 @@ describe('UploadFS Local', function () {
       },
       enable: cb => {
         uploadfs.enable(srcFile, e => {
-          var stats = fs.statSync(infile);
-          var mode = new Mode(stats);
+          const stats = fs.statSync(infile);
+          const mode = new Mode(stats);
           assert(!e, 'uploadfs disable success!');
           assert(mode.toString() === '-rw-r--r--', 'Enabled file has expected permissions');
           assert(fs.existsSync(infile), 'copyIn visible to fs');
@@ -117,7 +117,7 @@ describe('UploadFS Local', function () {
         });
       },
       testCopyOut: cb => {
-        var outsucceeds = 'copy-out-test.txt';
+        const outsucceeds = 'copy-out-test.txt';
         uploadfs.copyOut(srcFile, outsucceeds, e => {
           assert(!e, 'node should not be able to copy this file!');
           return cb(null);

--- a/uploadfs.js
+++ b/uploadfs.js
@@ -1,9 +1,9 @@
-var _ = require('lodash');
-var async = require('async');
-var crypto = require('crypto');
-var fs = require('fs');
-var rmRf = require('rimraf');
-var delimiter = require('path').delimiter;
+const _ = require('lodash');
+const async = require('async');
+const crypto = require('crypto');
+const fs = require('fs');
+const rmRf = require('rimraf');
+const delimiter = require('path').delimiter;
 
 function generateId() {
   return crypto.randomBytes(16).toString('hex');
@@ -15,10 +15,10 @@ function generateId() {
  */
 
 function Uploadfs() {
-  var tempPath, imageSizes;
-  var scaledJpegQuality;
-  var ensuredTempDir = false;
-  var self = this;
+  let tempPath, imageSizes;
+  let scaledJpegQuality;
+  let ensuredTempDir = false;
+  const self = this;
   /**
    * Initialize uploadfs. The init method passes options to the backend and invokes a callback when the backend is ready.
    * @param  {Object}   options: backend, imageSizes, orientOriginals, tempPath, copyOriginal, scaledJpegQuality, contentType, cdn. backend is the only mandatory option. See the README and individual methods for details.
@@ -261,15 +261,15 @@ function Uploadfs() {
       options = {};
     }
 
-    var sizes = options.sizes || imageSizes;
+    const sizes = options.sizes || imageSizes;
 
     ensureTempDir();
 
     // We'll pass this context to the image processing backend with
     // additional properties
-    var context = {
+    const context = {
       crop: options.crop,
-      sizes: sizes
+      sizes
     };
 
     context.scaledJpegQuality = options.scaledJpegQuality || scaledJpegQuality;
@@ -288,9 +288,9 @@ function Uploadfs() {
       });
     }
 
-    var originalDone = false;
-    var copyOriginal = options.copyOriginal !== false;
-    var originalPath;
+    let originalDone = false;
+    const copyOriginal = options.copyOriginal !== false;
+    let originalPath;
 
     async.series(
       {
@@ -355,7 +355,7 @@ function Uploadfs() {
               // Nowhere to do the work
               return callback(null);
             }
-            var filenames = _.map(sizes, function (size) {
+            const filenames = _.map(sizes, function (size) {
               return (
                 context.tempFolder + '/' + size.name + '.' + context.extension
               );
@@ -371,8 +371,8 @@ function Uploadfs() {
           // Push and pop the original size properties as we determined
           // those on the first identify and don't want to return the values
           // for the cropped and/or reoriented version
-          var originalWidth = context.info.originalWidth;
-          var originalHeight = context.info.originalHeight;
+          const originalWidth = context.info.originalWidth;
+          const originalHeight = context.info.originalHeight;
           return identify(context.adjustedOriginal, function (err) {
             if (err) {
               return callback(err);
@@ -387,9 +387,9 @@ function Uploadfs() {
           return async.each(
             sizes,
             function (size, callback) {
-              var suffix = size.name + '.' + context.extension;
-              var tempFile = context.tempFolder + '/' + suffix;
-              var permFile = context.basePath + '.' + suffix;
+              const suffix = size.name + '.' + context.extension;
+              const tempFile = context.tempFolder + '/' + suffix;
+              const permFile = context.basePath + '.' + suffix;
               return self.copyIn(tempFile, permFile, options, callback);
             },
             callback
@@ -541,7 +541,7 @@ function Uploadfs() {
    * @param {function} callback
    */
   self.destroy = function (callback) {
-    var callbacks = [
+    const callbacks = [
       self._storage.destroy || noOperation,
       self._image.destroy || noOperation
     ];
@@ -552,7 +552,7 @@ function Uploadfs() {
   };
 
   self.migrateToDisabledFileKey = function (callback) {
-    var method = self._storage.migrateToDisabledFileKey;
+    const method = self._storage.migrateToDisabledFileKey;
     if (!method) {
       // Not relevant for this backend
       return callback(null);
@@ -561,7 +561,7 @@ function Uploadfs() {
   };
 
   self.migrateFromDisabledFileKey = function (callback) {
-    var method = self._storage.migrateFromDisabledFileKey;
+    const method = self._storage.migrateFromDisabledFileKey;
     if (!method) {
       // Not relevant for this backend
       return callback(null);
@@ -573,22 +573,22 @@ function Uploadfs() {
   // for optimal file size, etc.
 
   self.postprocess = function (files, callback) {
-    var sample = files[0];
+    const sample = files[0];
     if (!sample) {
       return callback(null);
     }
-    var relevant = _.filter(
+    const relevant = _.filter(
       self.options.postprocessors || [],
       function (postprocessor) {
-        var matches = sample.match(/\.(\w+)$/);
+        const matches = sample.match(/\.(\w+)$/);
         if (!matches) {
           return false;
         }
-        var extension = matches[1];
+        const extension = matches[1];
         return _.includes(postprocessor.extensions, extension);
       }
     );
-    var folder = require('path').dirname(sample);
+    const folder = require('path').dirname(sample);
     return async.eachSeries(
       relevant,
       function (postprocessor, callback) {


### PR DESCRIPTION
See changelog. This is a small change that looks big because upgrading eslint stuff to please npm audit forced a move from "var" to "const/let", but also correctly updated every usage by itself. All tests passing and the code will be easier to keep correct now.

The other half of the fix was updating the google cloud storage API module, which did not break the GCS tests.

There is still an npm audit error due to eslint-config-plugin, which I'm sending an upstream PR for. We won't have to do anything on our end I expect.