### PR TITLE
release 1.23.0: introduce streamOut API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.23.0 (2024-10-14)
+
+* Introduced `streamOut` API for `local` and `s3` storage backends.
+
 ## 1.22.7 (2024-09-24)
 
 * `.mp3` does not benefit from gzip encoding and the transfer encoding header fails to be sent, so do not use it.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ You need:
 
 * The `copyOut` method takes a path in uploadfs and a local filename and copies the file back from uploadfs to the local filesystem. This should be used only rarely. Heavy reliance on this method sets you up for poor performance in S3 and Azure. However it may be necessary at times, for instance when you want to crop an image differently later. *Heavy reliance on copyOut is a recipe for bad S3 and/or Azure performance. Use it only for occasional operations like cropping.*
 
+* The `streamOut` method takes a path in uploadfs and returns a readable stream. This should be used only rarely. Heavy reliance on this method sets you up for poor performance in S3 and Azure. However it may be necessary at times, for instance when permissions must be checked on a request-by-request basis in a proxy route. **This method, which is not required for normal use in ApostropheCMS, is currently implemented only in the `local` and `s3` storage backends.** Contributions for Azure and GCS are welcome.
+
 * The `remove` method removes a file from uploadfs.
 
 * The `getUrl` method returns the URL to which you should append uploadfs paths to fetch them with a web browser.

--- a/lib/storage/local.js
+++ b/lib/storage/local.js
@@ -99,6 +99,10 @@ module.exports = function() {
       return copyFile(downloadPath, localPath, callback);
     },
 
+    streamOut: function(path, options) {
+      return fs.createReadStream(uploadsPath + path);
+    },
+
     remove: function(path, callback) {
       const uploadPath = uploadsPath + path;
       fs.unlink(uploadPath, callback);

--- a/lib/storage/s3.js
+++ b/lib/storage/s3.js
@@ -128,7 +128,6 @@ module.exports = function() {
       const request = client.getObject(params);
       let inputStream = request.createReadStream();
       request.on('httpHeaders', function(status, headers) {
-        let gunzip = null;
         if (headers['content-encoding'] === 'gzip') {
           const gunzip = require('zlib').createGunzip();
           inputStream.pipe(gunzip);

--- a/lib/storage/s3.js
+++ b/lib/storage/s3.js
@@ -8,6 +8,7 @@ const AWS = require('aws-sdk');
 const extname = require('path').extname;
 const _ = require('lodash');
 const utils = require('../utils');
+const { PassThrough } = require('stream');
 
 module.exports = function() {
   let contentTypes;
@@ -118,22 +119,31 @@ module.exports = function() {
       }
     },
 
-    copyOut: function(path, localPath, options, callback) {
+    streamOut: function(path, options) {
+      const result = new PassThrough();
       let finished = false;
-      const outputStream = fs.createWriteStream(localPath);
       const params = {
         Key: utils.removeLeadingSlash(self.options, path)
       };
       const request = client.getObject(params);
       let inputStream = request.createReadStream();
       request.on('httpHeaders', function(status, headers) {
+        let gunzip = null;
         if (headers['content-encoding'] === 'gzip') {
           const gunzip = require('zlib').createGunzip();
           inputStream.pipe(gunzip);
           inputStream = gunzip;
         }
-        inputStream.pipe(outputStream);
+        inputStream.pipe(result);
       });
+      return result;
+    },
+
+    copyOut: function(path, localPath, options, callback) {
+      let finished = false;
+      const outputStream = fs.createWriteStream(localPath);
+      const inputStream = self.streamOut(path, options);
+      inputStream.pipe(outputStream);
       inputStream.on('error', function(err) {
         // Watch out for any oddities in stream implementation
         if (finished) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uploadfs",
-  "version": "1.22.7",
+  "version": "1.23.0",
   "description": "Store files in a web-accessible location via a simplified API. Can automatically scale and rotate images. Includes S3, Azure and local filesystem-based backends with the most convenient features of each.",
   "main": "uploadfs.js",
   "scripts": {

--- a/test/local.js
+++ b/test/local.js
@@ -66,6 +66,17 @@ describe('UploadFS Local', function () {
     });
   });
 
+  it('streamOut should work for local filesystem', async function() {
+    const input = uploadfs.streamOut('/test_copy.txt');
+    const chunks = [];
+    for await (let chunk of input) {
+      chunks.push(chunk);
+    }
+    const data = Buffer.concat(chunks);
+    const og = fs.readFileSync('test.txt');
+    assert(data.equals(og));
+  });
+
   it('overwrite with copyIn should work for local filesystem', done => {
     return uploadfs.copyIn('./test2.txt', '/test_copy.txt', e => {
       assert(!e);

--- a/test/s3.js
+++ b/test/s3.js
@@ -109,6 +109,17 @@ describe('UploadFS S3', function () {
       });
   });
 
+  it('S3 streamOut should work', async function() {
+    const input = uploadfs.streamOut(dstPath);
+    const chunks = [];
+    for await (let chunk of input) {
+      chunks.push(chunk);
+    }
+    const data = Buffer.concat(chunks);
+    const og = fs.readFileSync('test.txt');
+    assert(data.equals(og), 'Streamed file is equal to previous upload');
+  });
+
   it('S3 CopyOut should work', done => {
     const cpOutPath = 'copy-out-test.txt';
     return uploadfs.copyOut(dstPath, cpOutPath, e => {

--- a/uploadfs.js
+++ b/uploadfs.js
@@ -199,6 +199,17 @@ function Uploadfs() {
   };
 
   /**
+   * The streamOut method takes a path in uploadfs and a local filename and returns a readable stream. This should be used only rarely. Heavy reliance on this method sets you up for poor performance in S3. However it may be necessary at times, for instance when access to files must be secured on a request-by-request basis.
+   * @param  {String}   path    Path in uploadfs (begins with /)
+   * @param  {Object}   options    Options (passed to backend). May be skipped
+   * @param  {Function} callback    Receives the usual err argument
+   */
+  self.streamOut = function (path, options) {
+    path = prefixPath(path);
+    return self._storage.streamOut(path, options);
+  };
+  
+  /**
    * Copy an image into uploadfs. Scaled versions as defined by the imageSizes option
    * passed at init() time, or as overridden by `options.sizes` on this call,
    * are copied into uploadfs as follows:


### PR DESCRIPTION
While it is still not a terribly performant thing to do, we have a need to support nuanced permission checks on each read to media stored in uploadfs, specifically the S3 backend.

The `apostrophe-secure-attachments` module could do that with `copyOut` followed by streaming the returned file every time but that makes performance even worse.

So implement a new `streamOut` method, with `local` and `s3` backends for now. Contributions welcome re: gcs and azure support.

We need this to unlock finishing our scaling work for WM.