### PR TITLE
release 1.24.0: fix bugs and incomplete support for specifying alternate ACLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.24.0 (2024-10-15)
+
+* Bug fix: `bucketObjectsACL` is respected by the `enable` method, that method no longer makes files `public` again. Previously it was only respected at `copyIn` / `copyImageIn` time.
+* New feature: `disabledBucketObjectsACL` is now also supported, it is used by the `disable` method rather than
+assuming `private` (still the default).
+
 ## 1.23.0 (2024-10-14)
 
 * Introduced `streamOut` API for `local` and `s3` storage backends.

--- a/lib/storage/s3.js
+++ b/lib/storage/s3.js
@@ -17,6 +17,7 @@ module.exports = function() {
   let https;
   let bucket;
   let bucketObjectsACL;
+  let disabledBucketObjectsACL;
   let endpoint;
   let defaultTypes;
   let noProtoEndpoint;
@@ -32,6 +33,7 @@ module.exports = function() {
       }
       bucket = options.bucket;
       bucketObjectsACL = options.bucketObjectsACL || 'public-read';
+      disabledBucketObjectsACL = options.disabledBucketObjectsACL || 'private';
       options.params = options.params || {};
       options.params.Bucket = options.params.Bucket || options.bucket;
       noGzipContentTypes = options.noGzipContentTypes || require('./noGzipContentTypes');
@@ -175,14 +177,14 @@ module.exports = function() {
 
     enable: function(path, callback) {
       return client.putObjectAcl({
-        ACL: 'public-read',
+        ACL: bucketObjectsACL,
         Key: utils.removeLeadingSlash(self.options, path)
       }, callback);
     },
 
     disable: function(path, callback) {
       return client.putObjectAcl({
-        ACL: 'private',
+        ACL: disabledBucketObjectsACL,
         Key: utils.removeLeadingSlash(self.options, path)
       }, callback);
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uploadfs",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "description": "Store files in a web-accessible location via a simplified API. Can automatically scale and rotate images. Includes S3, Azure and local filesystem-based backends with the most convenient features of each.",
   "main": "uploadfs.js",
   "scripts": {


### PR DESCRIPTION
* A third party contributed the `bucketObjectACL` option to override the default ACL of `public`, but it was never implemented for the `enable` method, which still made files `public`.
* There was never a corresponding `disabledBucketObjectACL` for overriding the behavior of the `disable` method. This has been fixed.

This is also part of my WM work.